### PR TITLE
Rename param variables in Query.hs

### DIFF
--- a/lib/PersistenceStore/SQLite/Query.hs
+++ b/lib/PersistenceStore/SQLite/Query.hs
@@ -105,14 +105,14 @@ metricIdParmQ = unsafeCoerce . metricIdParm
 
 buildLoadMeasurementsQuery
   :: TableName -> [ClubMetrics] -> Maybe Day -> Maybe Day -> (Query, [NamedParam])
-buildLoadMeasurementsQuery tableName clubMetrics startM endM = (query, parms)
- where
-  queriesAndParms = do
+buildLoadMeasurementsQuery tableName clubMetrics startM endM = (query, params)
+  where
+  queriesAndParams = do
     metric <- clubMetrics
     let subQuery = buildLoadMeasurementsSubQuery tableName metric startM endM
-        parm = metricIdParm metric := fromEnum metric
-    pure (subQuery, parm)
-  (subQueries, parms) = unzip queriesAndParms
+        param = metricIdParm metric := fromEnum metric
+    pure (subQuery, param)
+  (subQueries, params) = unzip queriesAndParams
   query = mconcat (intersperse " UNION ALL " subQueries) <> " ORDER BY metric_id"
 
 buildLoadMeasurementsSubQuery


### PR DESCRIPTION
## Summary
- rename variables `parm` and `parms` to `param` and `params`
- adjust helper name accordingly

## Testing
- `cabal build` *(fails: building dependencies takes too long)*
- `cabal test` *(fails: building dependencies takes too long)*

------
https://chatgpt.com/codex/tasks/task_e_684d37d031f883259b1abb83da6b96d0