### PR TITLE
Rename ClubMetrics type

### DIFF
--- a/lib/PersistenceStore/ClubMetrics.hs
+++ b/lib/PersistenceStore/ClubMetrics.hs
@@ -1,14 +1,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 
-module PersistenceStore.ClubMetrics (ClubMetrics (..)) where
+module PersistenceStore.ClubMetrics (ClubMetric (..)) where
 
 import Autodocodec (HasCodec, codec, shownBoundedEnumCodec)
 import GHC.Generics (Generic)
 import TextShow (FromStringShow (..), TextShow)
 import Prelude
 
-data ClubMetrics
+data ClubMetric
   = ActiveMembers
   | Area
   | ClubName
@@ -30,6 +30,6 @@ data ClubMetrics
   | OfficersTrainedRoundTwo
   | ReportingMonth
   deriving stock (Bounded, Enum, Eq, Generic, Read, Show)
-  deriving TextShow via FromStringShow ClubMetrics
-instance HasCodec ClubMetrics where
+  deriving TextShow via FromStringShow ClubMetric
+instance HasCodec ClubMetric where
   codec = shownBoundedEnumCodec

--- a/lib/PersistenceStore/SQLite/Insert.hs
+++ b/lib/PersistenceStore/SQLite/Insert.hs
@@ -28,7 +28,7 @@ import Prelude
 
 import MonadStack (AppM)
 import PersistenceStore.Analyzer (analyze)
-import PersistenceStore.ClubMetrics (ClubMetrics (ReportingMonth))
+import PersistenceStore.ClubMetrics (ClubMetric (ReportingMonth))
 import PersistenceStore.Measurement (DbDate (..), Measurement (..))
 import PersistenceStore.SQLite.Class
   ( TableName (..)

--- a/lib/PersistenceStore/SQLite/Tables.hs
+++ b/lib/PersistenceStore/SQLite/Tables.hs
@@ -17,7 +17,7 @@ import UnliftIO (liftIO)
 import Prelude
 
 import MonadStack (AppM)
-import PersistenceStore.ClubMetrics (ClubMetrics)
+import PersistenceStore.ClubMetrics (ClubMetric)
 import PersistenceStore.SQLite.Class
   ( TableName (..)
   , intMeasurementTable
@@ -52,7 +52,7 @@ createMetricNameTable conn = do
       \, name TEXT    NOT NULL \
       \);"
   logFM InfoS "(Conditionally) created table metric_names."
-  let insert :: ClubMetrics -> AppM ()
+  let insert :: ClubMetric -> AppM ()
       insert m =
         liftIO $
           executeNamed

--- a/lib/Serve/ClubMeasurement.hs
+++ b/lib/Serve/ClubMeasurement.hs
@@ -15,7 +15,7 @@ import TextShow (showt)
 import TextShow.Data.Time ()
 import Prelude
 
-import PersistenceStore.ClubMetrics (ClubMetrics (..))
+import PersistenceStore.ClubMetrics (ClubMetric (..))
 import PersistenceStore.Measurement (DbDate (..), Measurement (..))
 import PersistenceStore.SQLite.Query (loadIntMeasurements, loadTextMeasurements)
 import Serve.Class (AppHandler)
@@ -48,7 +48,7 @@ buildTextSeries xs = toSeries TextCodomain <$> groupWith metricId xs
 toSeries :: forall a. ([a] -> Codomain) -> NonEmpty (Measurement a) -> Series
 toSeries toCodomain nel@(m :| _) = Series label domain codomain
  where
-  label = T.show (toEnum (metricId m) :: ClubMetrics)
+  label = T.show (toEnum (metricId m) :: ClubMetric)
   domain = toList $ formatDbDate . date <$> nel
   codomain = toCodomain $ toList $ value <$> nel
 

--- a/lib/Serve/ClubMetadata.hs
+++ b/lib/Serve/ClubMetadata.hs
@@ -15,8 +15,8 @@ import Servant.Server (err404, err500)
 import UnliftIO (liftIO)
 import Prelude hiding (div)
 
-import PersistenceStore.ClubMetrics (ClubMetrics)
-import PersistenceStore.ClubMetrics qualified as M (ClubMetrics (..))
+import PersistenceStore.ClubMetrics (ClubMetric)
+import PersistenceStore.ClubMetrics qualified as M (ClubMetric (..))
 import PersistenceStore.Measurement (Measurement (..))
 import PersistenceStore.SQLite.Query (loadIntMeasurements, loadTextMeasurements)
 import Serve.Class (AppHandler)
@@ -64,11 +64,11 @@ loadNameAndDivision clubNumber today = do
                     ls $
                       mconcat
                         [ "Expected club name and division, but found [metricId "
-                        , T.show (toEnum m0 :: ClubMetrics)
+                        , T.show (toEnum m0 :: ClubMetric)
                         , ", value "
                         , T.show v0
                         , " : metricId "
-                        , T.show (toEnum m1 :: ClubMetrics)
+                        , T.show (toEnum m1 :: ClubMetric)
                         , ", value "
                         , T.show v1
                         , "]"

--- a/lib/Types/ClubMeasurementRequest.hs
+++ b/lib/Types/ClubMeasurementRequest.hs
@@ -11,12 +11,12 @@ import Data.OpenApi (ToSchema (..))
 import Data.Time (Day)
 import GHC.Generics (Generic)
 
-import PersistenceStore.ClubMetrics (ClubMetrics)
+import PersistenceStore.ClubMetrics (ClubMetric)
 import Types.ClubNumber (ClubNumber)
 
 data ClubMeasurementRequest = ClubMeasurementRequest
   { clubNumber :: !ClubNumber
-  , metrics :: ![ClubMetrics]
+  , metrics :: ![ClubMetric]
   , startDate :: !(Maybe Day)
   , endDate :: !(Maybe Day)
   }

--- a/test/Unit/Libs.hs
+++ b/test/Unit/Libs.hs
@@ -12,7 +12,7 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 import Prelude
 
-import PersistenceStore.ClubMetrics (ClubMetrics (..))
+import PersistenceStore.ClubMetrics (ClubMetric (..))
 import PersistenceStore.Measurement (DbDate (..), Measurement (..))
 import Serve.ClubMeasurement (buildIntSeries)
 import Types.ClubMeasurementResponse (Codomain (..), Series (..))


### PR DESCRIPTION
## Summary
- rename the `ClubMetrics` type to `ClubMetric`
- update usages across serving code, SQLite layer, and tests

## Testing
- `cabal test all` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d3bb149948325a8ba8f5b38eba8f9