### PR TITLE
Use fromString for metricIdParamQ

### DIFF
--- a/lib/PersistenceStore/SQLite/Query.hs
+++ b/lib/PersistenceStore/SQLite/Query.hs
@@ -15,7 +15,7 @@ module PersistenceStore.SQLite.Query
 
 import Data.List (intersperse)
 import Data.Text (Text)
-import Data.Text as T (concat, show, toCaseFold)
+import Data.Text as T (concat, show, toCaseFold, unpack)
 import Data.Time (Day)
 import Database.SQLite.Simple
   ( Connection
@@ -26,7 +26,7 @@ import Database.SQLite.Simple
   )
 import Katip (Severity (..), logFM, ls)
 import UnliftIO (liftIO)
-import Unsafe.Coerce (unsafeCoerce)
+import Data.String (fromString)
 import Prelude
 
 import AppM (AppM)
@@ -101,7 +101,7 @@ endDateParamQ = ":end"
 metricIdParam :: ClubMetric -> Text
 metricIdParam metric = T.concat [":", T.toCaseFold $ T.show metric]
 metricIdParamQ :: ClubMetric -> Query
-metricIdParamQ = unsafeCoerce . metricIdParam
+metricIdParamQ = fromString . T.unpack . metricIdParam
 
 buildLoadMeasurementsQuery
   :: TableName -> [ClubMetric] -> Maybe Day -> Maybe Day -> (Query, [NamedParam])


### PR DESCRIPTION
## Summary
- make metricIdParamQ use safe conversion via `fromString`
- update imports

## Testing
- `cabal test --test-show-details=direct` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684db06b10cc8325817e818fd2551ec5