### PR TITLE
Introduce parseNameDivision helper

### DIFF
--- a/lib/Serve/ClubMetadata.hs
+++ b/lib/Serve/ClubMetadata.hs
@@ -56,7 +56,7 @@ loadNameAndDivision clubNumber today = do
     Right result -> pure result
 
 -- | Parse the combination of club name and division returned from the database.
-parseNameDivision :: [Measurement Text] -> Either Text (Maybe Text, Maybe Text)
+parseNameDivision :: forall a. Show a => [Measurement a] -> Either Text (Maybe a, Maybe a)
 parseNameDivision namesAndDivisions = case namesAndDivisions of
   [] -> Right (Nothing, Nothing)
   [Measurement{metricId = m0, value = v0}, Measurement{metricId = m1, value = v1}] ->

--- a/test/Unit/Libs.hs
+++ b/test/Unit/Libs.hs
@@ -7,6 +7,7 @@ import Data.Bifunctor (second)
 import Data.List (sortBy)
 import Data.Ord (comparing)
 import Data.Text (Text)
+import Data.Text qualified as T (show)
 import Data.Time (pattern YearMonthDay)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
@@ -14,6 +15,7 @@ import Prelude
 
 import PersistenceStore.Measurement (DbDate (..), Measurement (..))
 import Serve.ClubMeasurement (buildIntSeries)
+import Serve.ClubMetadata (parseNameDivision)
 import Types.ClubMeasurementResponse (Codomain (..), Series (..))
 import Types.ClubMetric (ClubMetric (..))
 import Types.ClubNumber (ClubNumber (..))
@@ -35,7 +37,7 @@ tests =
     "Serve"
     [ testGroup
         "buildIntSeries"
-        [ testCase "Three row result set" $ do
+          [ testCase "Three row result set" $ do
             let clubId = ClubNumber 2490993
                 rs =
                   [ Measurement
@@ -70,6 +72,55 @@ tests =
                       , codomain = IntCodomain [15]
                       }
                   ]
+          actual @?= expected
+        ]
+    , testGroup
+        "parseNameDivision"
+        [ testCase "Empty list" $ do
+            let actual = parseNameDivision []
+                expected = Right (Nothing, Nothing)
+            actual @?= expected
+        , testCase "Name then division" $ do
+            let clubId = ClubNumber 1
+                baseDate = DbDate (YearMonthDay 2025 5 1)
+                name = Measurement {clubId, metricId = fromEnum ClubName, value = "Foo", date = baseDate}
+                division = Measurement {clubId, metricId = fromEnum Division, value = "A", date = baseDate}
+                actual = parseNameDivision [name, division]
+                expected = Right (Just "Foo", Just "A")
+            actual @?= expected
+        , testCase "Division then name" $ do
+            let clubId = ClubNumber 1
+                baseDate = DbDate (YearMonthDay 2025 5 1)
+                name = Measurement {clubId, metricId = fromEnum ClubName, value = "Foo", date = baseDate}
+                division = Measurement {clubId, metricId = fromEnum Division, value = "A", date = baseDate}
+                actual = parseNameDivision [division, name]
+                expected = Right (Just "Foo", Just "A")
+            actual @?= expected
+        , testCase "Unexpected metrics" $ do
+            let clubId = ClubNumber 1
+                baseDate = DbDate (YearMonthDay 2025 5 1)
+                m0 = Measurement {clubId, metricId = fromEnum ActiveMembers, value = "10", date = baseDate}
+                m1 = Measurement {clubId, metricId = fromEnum MembershipBase, value = "15", date = baseDate}
+                actual = parseNameDivision [m0, m1]
+                expected = Left $
+                  mconcat
+                    [ "Expected club name and division, but found [metricId "
+                    , T.show ActiveMembers
+                    , ", value "
+                    , T.show "10"
+                    , " : metricId "
+                    , T.show MembershipBase
+                    , ", value "
+                    , T.show "15"
+                    , "]"
+                    ]
+            actual @?= expected
+        , testCase "Wrong length" $ do
+            let clubId = ClubNumber 1
+                baseDate = DbDate (YearMonthDay 2025 5 1)
+                name = Measurement {clubId, metricId = fromEnum ClubName, value = "Foo", date = baseDate}
+                actual = parseNameDivision [name]
+                expected = Left $ "Expected list length of 0 or 2, but found " <> T.show [name]
             actual @?= expected
         ]
     ]

--- a/test/Unit/Libs.hs
+++ b/test/Unit/Libs.hs
@@ -77,14 +77,17 @@ tests =
     , testGroup
         "parseNameDivision"
         [ testCase "Empty list" $ do
-            let actual = parseNameDivision []
-                expected = Right (Nothing, Nothing)
+            let actual = parseNameDivision [] :: Either Text (Maybe Int, Maybe Int)
+                expected = Right (Nothing, Nothing) :: Either Text (Maybe Int, Maybe Int)
             actual @?= expected
         , testCase "Name then division" $ do
             let clubId = ClubNumber 1
                 baseDate = DbDate (YearMonthDay 2025 5 1)
-                name = Measurement{clubId, metricId = fromEnum ClubName, value = "Foo", date = baseDate}
-                division = Measurement{clubId, metricId = fromEnum Division, value = "A", date = baseDate}
+                name =
+                  Measurement{clubId, metricId = fromEnum ClubName, value = "Foo", date = baseDate}
+                    :: Measurement Text
+                division =
+                  Measurement{clubId, metricId = fromEnum Division, value = "A", date = baseDate} :: Measurement Text
                 actual = parseNameDivision [name, division]
                 expected = Right (Just "Foo", Just "A")
             actual @?= expected
@@ -93,35 +96,34 @@ tests =
                 baseDate = DbDate (YearMonthDay 2025 5 1)
                 name = Measurement{clubId, metricId = fromEnum ClubName, value = "Foo", date = baseDate}
                 division = Measurement{clubId, metricId = fromEnum Division, value = "A", date = baseDate}
-                actual = parseNameDivision [division, name]
-                expected = Right (Just "Foo", Just "A")
+                actual = parseNameDivision [division, name] :: Either Text (Maybe Text, Maybe Text)
+                expected = Right (Just "Foo", Just "A") :: Either Text (Maybe Text, Maybe Text)
             actual @?= expected
         , testCase "Unexpected metrics" $ do
             let clubId = ClubNumber 1
                 baseDate = DbDate (YearMonthDay 2025 5 1)
-                m0 = Measurement{clubId, metricId = fromEnum ActiveMembers, value = "10", date = baseDate}
-                m1 = Measurement{clubId, metricId = fromEnum MembershipBase, value = "15", date = baseDate}
-                actual = parseNameDivision [m0, m1]
+                m0 = Measurement{clubId, metricId = fromEnum ActiveMembers, value = 10, date = baseDate}
+                m1 = Measurement{clubId, metricId = fromEnum MembershipBase, value = 15, date = baseDate}
+                actual = parseNameDivision [m0, m1] :: Either Text (Maybe Int, Maybe Int)
                 expected =
                   Left $
                     mconcat
                       [ "Expected club name and division, but found [metricId "
                       , T.show ActiveMembers
-                      , ", value "
-                      , "10"
-                      , " : metricId "
+                      , ", value 10 : metricId "
                       , T.show MembershipBase
-                      , ", value "
-                      , "15"
-                      , "]"
+                      , ", value 15]"
                       ]
+                    :: Either Text (Maybe Int, Maybe Int)
             actual @?= expected
         , testCase "Wrong length" $ do
             let clubId = ClubNumber 1
                 baseDate = DbDate (YearMonthDay 2025 5 1)
                 name = Measurement{clubId, metricId = fromEnum ClubName, value = "Foo", date = baseDate}
                 actual = parseNameDivision [name]
-                expected = Left $ "Expected list length of 0 or 2, but found " <> T.show [name]
+                expected =
+                  Left $ "Expected list length of 0 or 2, but found " <> T.show [name]
+                    :: Either Text (Maybe Text, Maybe Text)
             actual @?= expected
         ]
     ]

--- a/test/Unit/Libs.hs
+++ b/test/Unit/Libs.hs
@@ -37,7 +37,7 @@ tests =
     "Serve"
     [ testGroup
         "buildIntSeries"
-          [ testCase "Three row result set" $ do
+        [ testCase "Three row result set" $ do
             let clubId = ClubNumber 2490993
                 rs =
                   [ Measurement
@@ -72,7 +72,7 @@ tests =
                       , codomain = IntCodomain [15]
                       }
                   ]
-          actual @?= expected
+            actual @?= expected
         ]
     , testGroup
         "parseNameDivision"
@@ -83,42 +83,43 @@ tests =
         , testCase "Name then division" $ do
             let clubId = ClubNumber 1
                 baseDate = DbDate (YearMonthDay 2025 5 1)
-                name = Measurement {clubId, metricId = fromEnum ClubName, value = "Foo", date = baseDate}
-                division = Measurement {clubId, metricId = fromEnum Division, value = "A", date = baseDate}
+                name = Measurement{clubId, metricId = fromEnum ClubName, value = "Foo", date = baseDate}
+                division = Measurement{clubId, metricId = fromEnum Division, value = "A", date = baseDate}
                 actual = parseNameDivision [name, division]
                 expected = Right (Just "Foo", Just "A")
             actual @?= expected
         , testCase "Division then name" $ do
             let clubId = ClubNumber 1
                 baseDate = DbDate (YearMonthDay 2025 5 1)
-                name = Measurement {clubId, metricId = fromEnum ClubName, value = "Foo", date = baseDate}
-                division = Measurement {clubId, metricId = fromEnum Division, value = "A", date = baseDate}
+                name = Measurement{clubId, metricId = fromEnum ClubName, value = "Foo", date = baseDate}
+                division = Measurement{clubId, metricId = fromEnum Division, value = "A", date = baseDate}
                 actual = parseNameDivision [division, name]
                 expected = Right (Just "Foo", Just "A")
             actual @?= expected
         , testCase "Unexpected metrics" $ do
             let clubId = ClubNumber 1
                 baseDate = DbDate (YearMonthDay 2025 5 1)
-                m0 = Measurement {clubId, metricId = fromEnum ActiveMembers, value = "10", date = baseDate}
-                m1 = Measurement {clubId, metricId = fromEnum MembershipBase, value = "15", date = baseDate}
+                m0 = Measurement{clubId, metricId = fromEnum ActiveMembers, value = "10", date = baseDate}
+                m1 = Measurement{clubId, metricId = fromEnum MembershipBase, value = "15", date = baseDate}
                 actual = parseNameDivision [m0, m1]
-                expected = Left $
-                  mconcat
-                    [ "Expected club name and division, but found [metricId "
-                    , T.show ActiveMembers
-                    , ", value "
-                    , T.show "10"
-                    , " : metricId "
-                    , T.show MembershipBase
-                    , ", value "
-                    , T.show "15"
-                    , "]"
-                    ]
+                expected =
+                  Left $
+                    mconcat
+                      [ "Expected club name and division, but found [metricId "
+                      , T.show ActiveMembers
+                      , ", value "
+                      , "10"
+                      , " : metricId "
+                      , T.show MembershipBase
+                      , ", value "
+                      , "15"
+                      , "]"
+                      ]
             actual @?= expected
         , testCase "Wrong length" $ do
             let clubId = ClubNumber 1
                 baseDate = DbDate (YearMonthDay 2025 5 1)
-                name = Measurement {clubId, metricId = fromEnum ClubName, value = "Foo", date = baseDate}
+                name = Measurement{clubId, metricId = fromEnum ClubName, value = "Foo", date = baseDate}
                 actual = parseNameDivision [name]
                 expected = Left $ "Expected list length of 0 or 2, but found " <> T.show [name]
             actual @?= expected


### PR DESCRIPTION
## Summary
- parse helper for club name & division
- use helper in ClubMetadata
- unit test parseNameDivision

## Testing
- `cabal test --test-show-details=streaming` *(fails: could not finish building dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684db081478483258a2ea4ecb32902a7