### PR TITLE
Implement decodeClubReport and tests

### DIFF
--- a/lib/Download.hs
+++ b/lib/Download.hs
@@ -9,9 +9,17 @@ Module      : Download
 Description : Functions for downloading club performance reports.
 Maintainer  : tomsnee@gmail.com
 -}
-module Download (CsvOctetStream (..), download, downloadClubPerformanceStarting, parseFooter) where
+module Download
+  ( CsvOctetStream (..)
+  , download
+  , downloadClubPerformanceStarting
+  , parseFooter
+  , decodeClubReport
+  )
+where
 
 import Control.Monad.Reader (ask)
+import Data.Bifunctor (first)
 import Data.ByteString.Lazy.Char8 qualified as BL8
 import Data.Csv (decodeByName)
 import Data.Either.Combinators (maybeToRight)
@@ -157,17 +165,24 @@ download env spec@ClubPerformanceReportDescriptor{format} = do
 
 newtype CsvOctetStream = CsvOctetStream OctetStream
   deriving Accept via OctetStream
+
+-- | Decode a CSV club performance report.
+decodeClubReport :: BL8.ByteString -> Either Text ClubPerformanceReport
+decodeClubReport bytes = do
+  let rows = BL8.lines bytes
+  (rawCsv, footer) <-
+    maybeToRight
+      ("Could not break " <> T.show (BL8.length bytes) <> " bytes into lines.")
+      $ unsnoc rows
+  (_, parsedCsv) <- first T.pack $ decodeByName $ BL8.unlines rawCsv
+  (monthReported, dayOfRecord) <- first T.pack $ parseFooter $ BL8.unpack footer
+  let YearMonth yearOfRecord monthOfRecord = dayPeriod dayOfRecord
+      yearReported = if monthReported <= monthOfRecord then yearOfRecord else pred yearOfRecord
+      records = toList parsedCsv
+  pure ClubPerformanceReport{dayOfRecord, month = YearMonth yearReported monthReported, records}
+
 instance MimeUnrender CsvOctetStream ClubPerformanceReport where
-  mimeUnrender _ bytes = do
-    let rows = BL8.lines bytes
-    (rawCsv, footer) <-
-      maybeToRight ("Could not break " <> show (BL8.length bytes) <> " bytes into lines.") $ unsnoc rows
-    (_, parsedCsv) <- decodeByName $ BL8.unlines rawCsv
-    (monthReported, dayOfRecord) <- parseFooter $ BL8.unpack footer
-    let YearMonth yearOfRecord monthOfRecord = dayPeriod dayOfRecord
-        yearReported = if monthReported <= monthOfRecord then yearOfRecord else pred yearOfRecord
-        records = toList parsedCsv
-    pure ClubPerformanceReport{dayOfRecord, month = YearMonth yearReported monthReported, records}
+  mimeUnrender _ bytes = first T.unpack $ decodeClubReport bytes
 
 -- Example footer: "Month of Apr, As of 05/01/2025"
 -- String type used by Cassava.

--- a/test/Unit/Apps.hs
+++ b/test/Unit/Apps.hs
@@ -3,12 +3,17 @@
 
 module Unit.Apps where
 
+import Data.ByteString.Lazy.Char8 qualified as BL8
+import Data.List (intercalate)
 import Data.Time (pattern YearMonthDay)
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (testCase, (@?=))
+import Test.Tasty.HUnit (assertEqual, assertFailure, testCase, (@?=))
 import Prelude
 
-import Download (parseFooter)
+import Download (decodeClubReport, parseFooter)
+import Types.ClubNumber (ClubNumber (..))
+import Types.ClubPerformanceReport (ClubPerformanceReport (..), ClubPerformanceRecord (..))
+import Data.Time.Calendar.Month (pattern YearMonth)
 
 tests :: TestTree
 tests =
@@ -32,5 +37,133 @@ tests =
                 expected =
                   Left $ "Could not parse date from fragment ', As of 13/01/2025' of CSV footer '" <> footer <> "'."
             actual @?= expected
+        ]
+    , testGroup
+        "decodeClubReport"
+        [ testCase "Empty report" $ do
+            let headerFields =
+                  [ "District"
+                  , "Division"
+                  , "Area"
+                  , "Club Number"
+                  , "Club Name"
+                  , "Club Status"
+                  , "Mem. Base"
+                  , "Active Members"
+                  , "Goals Met"
+                  , "Level 1s"
+                  , "Level 2s"
+                  , "Add. Level 2s"
+                  , "Level 3s"
+                  , "Level 4s, Level 5s, or DTM award"
+                  , "Add. Level 4s, Level 5s, or DTM award"
+                  , "New Members"
+                  , "Add. New Members"
+                  , "Off. Trained Round 1"
+                  , "Off. Trained Round 2"
+                  , "Mem. dues on time Oct"
+                  , "Mem. dues on time Apr"
+                  , "Off. List On Time"
+                  , "Club Distinguished Status"
+                  ]
+                mkLine xs = BL8.pack (intercalate "," (map show xs) <> "\r\n")
+                header = mkLine headerFields
+                footer = BL8.pack "Month of May, As of 05/01/2025\r\n"
+                csv = header <> footer
+            case decodeClubReport csv of
+              Left err -> assertFailure (show err)
+              Right ClubPerformanceReport{month, dayOfRecord, records} -> do
+                month @?= YearMonth 2025 5
+                dayOfRecord @?= YearMonthDay 2025 5 1
+                assertEqual "records" 0 (length records)
+        , testCase "Two row report" $ do
+            let headerFields =
+                  [ "District"
+                  , "Division"
+                  , "Area"
+                  , "Club Number"
+                  , "Club Name"
+                  , "Club Status"
+                  , "Mem. Base"
+                  , "Active Members"
+                  , "Goals Met"
+                  , "Level 1s"
+                  , "Level 2s"
+                  , "Add. Level 2s"
+                  , "Level 3s"
+                  , "Level 4s, Level 5s, or DTM award"
+                  , "Add. Level 4s, Level 5s, or DTM award"
+                  , "New Members"
+                  , "Add. New Members"
+                  , "Off. Trained Round 1"
+                  , "Off. Trained Round 2"
+                  , "Mem. dues on time Oct"
+                  , "Mem. dues on time Apr"
+                  , "Off. List On Time"
+                  , "Club Distinguished Status"
+                  ]
+                mkLine xs = BL8.pack (intercalate "," (map show xs) <> "\r\n")
+                header = mkLine headerFields
+                row1Fields =
+                  [ "112"
+                  , "K"
+                  , "01"
+                  , "00001666"
+                  , "Whangarei Toastmasters Club"
+                  , "Active"
+                  , "24"
+                  , "18"
+                  , "7"
+                  , "4"
+                  , "2"
+                  , "1"
+                  , "2"
+                  , "1"
+                  , "3"
+                  , "3"
+                  , "0"
+                  , "5"
+                  , "7"
+                  , "1"
+                  , "1"
+                  , "1"
+                  , ""
+                  ]
+                row2Fields =
+                  [ "112"
+                  , "K"
+                  , "01"
+                  , "00940555"
+                  , "Toastmasters @ Lunchtime"
+                  , "Active"
+                  , "14"
+                  , "19"
+                  , "8"
+                  , "5"
+                  , "2"
+                  , "1"
+                  , "0"
+                  , "1"
+                  , "1"
+                  , "4"
+                  , "10"
+                  , "4"
+                  , "4"
+                  , "1"
+                  , "1"
+                  , "1"
+                  , "S"
+                  ]
+                footer = BL8.pack "Month of May, As of 05/15/2025\r\n"
+                csv = header <> mkLine row1Fields <> mkLine row2Fields <> footer
+            case decodeClubReport csv of
+              Left err -> assertFailure (show err)
+              Right ClubPerformanceReport{month, dayOfRecord, records} -> do
+                month @?= YearMonth 2025 5
+                dayOfRecord @?= YearMonthDay 2025 5 15
+                assertEqual "records" 2 (length records)
+                let ClubPerformanceRecord{clubNumber, clubName} = head records
+                clubNumber @?= ClubNumber 1666
+                clubName @?= "Whangarei Toastmasters Club"
         ]
     ]

--- a/ts-data.cabal
+++ b/ts-data.cabal
@@ -290,6 +290,7 @@ test-suite ts-data-test
     -- Test dependencies.
     build-depends:
         base >=4.17,
+        bytestring ^>=0.12.0.2,
         katip ^>=0.8.8.2,
         mtl ^>=2.3.1,
         servant ^>=0.20.3,


### PR DESCRIPTION
## Summary
- implement `decodeClubReport` to parse club performance reports
- use `decodeClubReport` in the `MimeUnrender` instance
- test CSV decoding with empty and populated sample data

## Testing
- `cabal test` *(fails: building dependencies requires downloads)*

------
https://chatgpt.com/codex/tasks/task_e_684db0ec567883258c4bdef719ee20b3