### PR TITLE
Generalize SQLite Query and Insert functions

### DIFF
--- a/lib/PersistenceStore/SQLite/Common.hs
+++ b/lib/PersistenceStore/SQLite/Common.hs
@@ -22,7 +22,7 @@ import Database.SQLite.Simple
   , execute_
   , open
   )
-import UnliftIO (MonadUnliftIO, bracket, liftIO)
+import UnliftIO (liftIO)
 import Prelude
 
 import Types.AppEnv (AppEnv (..))
@@ -35,8 +35,15 @@ testDatabase :: DatabaseName
 testDatabase = DatabaseName ":memory:"
 
 withDatabase
-  :: forall a m. (MonadIO m, MonadReader AppEnv m, MonadUnliftIO m) => (Connection -> m a) -> m a
-withDatabase = bracket openDatabase (liftIO . close)
+  :: forall a m.
+     (MonadIO m, MonadReader AppEnv m)
+  => (Connection -> m a)
+  -> m a
+withDatabase action = do
+  conn <- openDatabase
+  result <- action conn
+  liftIO $ close conn
+  pure result
 
 openDatabase :: (MonadIO m, MonadReader AppEnv m) => m Connection
 openDatabase = do

--- a/lib/PersistenceStore/SQLite/Query.hs
+++ b/lib/PersistenceStore/SQLite/Query.hs
@@ -23,61 +23,104 @@ import Database.SQLite.Simple
   , NamedParam (..)
   , Query (..)
   , queryNamed
+  , execute_
+  , open
+  , close
   )
-import Katip (Severity (..), logFM, ls)
-import UnliftIO (liftIO)
+import Katip (KatipContext, Severity (..), logFM, ls)
+import UnliftIO (MonadIO, liftIO)
 import Unsafe.Coerce (unsafeCoerce)
 import Prelude
 
-import AppM (AppM)
+import Control.Monad.Reader (MonadReader, ask)
 import PersistenceStore.Measurement (Measurement (..))
 import PersistenceStore.SQLite.Common
   ( TableName (..)
   , intMeasurementTable
   , textMeasurementTable
-  , withDatabase
   )
+import Types.Conf (Conf (..))
+import Types.DatabaseName (DatabaseName (..))
+import Types.AppEnv (AppEnv)
 import Types.ClubMetric (ClubMetric (..))
 import Types.ClubNumber (ClubNumber (..))
 
 loadIntMeasurements
-  :: ClubNumber -> [ClubMetric] -> Maybe Day -> Maybe Day -> AppM [Measurement Int]
+  :: (MonadIO m, MonadReader AppEnv m, KatipContext m)
+  => ClubNumber
+  -> [ClubMetric]
+  -> Maybe Day
+  -> Maybe Day
+  -> m [Measurement Int]
 loadIntMeasurements = loadMeasurements intMeasurementTable
 
 loadIntMeasurementsWithConnection
-  :: Connection -> ClubNumber -> [ClubMetric] -> Maybe Day -> Maybe Day -> AppM [Measurement Int]
+  :: MonadIO m
+  => Connection
+  -> ClubNumber
+  -> [ClubMetric]
+  -> Maybe Day
+  -> Maybe Day
+  -> m [Measurement Int]
 loadIntMeasurementsWithConnection conn = loadMeasurementsWithConnection conn intMeasurementTable
 
 loadTextMeasurements
-  :: ClubNumber -> [ClubMetric] -> Maybe Day -> Maybe Day -> AppM [Measurement Text]
+  :: (MonadIO m, MonadReader AppEnv m, KatipContext m)
+  => ClubNumber
+  -> [ClubMetric]
+  -> Maybe Day
+  -> Maybe Day
+  -> m [Measurement Text]
 loadTextMeasurements = loadMeasurements textMeasurementTable
 
 loadTextMeasurementsWithConnection
-  :: Connection -> ClubNumber -> [ClubMetric] -> Maybe Day -> Maybe Day -> AppM [Measurement Text]
+  :: MonadIO m
+  => Connection
+  -> ClubNumber
+  -> [ClubMetric]
+  -> Maybe Day
+  -> Maybe Day
+  -> m [Measurement Text]
 loadTextMeasurementsWithConnection conn = loadMeasurementsWithConnection conn textMeasurementTable
 
 loadMeasurements
-  :: forall a
-   . FromRow (Measurement a)
+  :: forall m a
+   . ( MonadIO m
+     , MonadReader AppEnv m
+     , KatipContext m
+     , FromRow (Measurement a)
+     )
   => TableName
   -> ClubNumber
   -> [ClubMetric]
   -> Maybe Day
   -> Maybe Day
-  -> AppM [Measurement a]
-loadMeasurements tableName clubNumber metrics startM endM = withDatabase $
-  \conn -> loadMeasurementsWithConnection conn tableName clubNumber metrics startM endM
+  -> m [Measurement a]
+loadMeasurements tableName clubNumber metrics startM endM = do
+  AppEnv{conf = Conf{databaseName = DatabaseName dbName}} <- ask
+  conn <- liftIO $ open dbName
+  liftIO $ execute_ conn "PRAGMA foreign_keys = ON"
+  result <-
+    loadMeasurementsWithConnection
+      conn
+      tableName
+      clubNumber
+      metrics
+      startM
+      endM
+  liftIO $ close conn
+  pure result
 
 loadMeasurementsWithConnection
-  :: forall a
-   . FromRow (Measurement a)
+  :: forall m a
+   . (MonadIO m, KatipContext m, FromRow (Measurement a))
   => Connection
   -> TableName
   -> ClubNumber
   -> [ClubMetric]
   -> Maybe Day
   -> Maybe Day
-  -> AppM [Measurement a]
+  -> m [Measurement a]
 loadMeasurementsWithConnection conn tableName clubNumber metrics startM endM = do
   let (query, metricParams) = buildLoadMeasurementsQuery tableName metrics startM endM
   logFM DebugS $ ls $ fromQuery query


### PR DESCRIPTION
## Summary
- open and close SQLite connections directly in `saveReport` and `loadMeasurements`
- remove dependency on `withDatabase`
- allow usage from any `MonadIO` & `MonadReader AppEnv` stack

## Testing
- `cabal test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684db019199083258a2a2a1d176c9405