### PR TITLE
Refactor test helpers

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           target: cabal:ts-data-test
           src: app,lib
-          excludes: Main,System.AppTestCase,System.Persistence,Unit.Libs.Download.MealyMachine,Unit.Libs.Download.Parsers,Unit.Libs.Download.Time,Unit.Libs.Serve,Unit.Libs.Types.ClubPerformanceReportDescriptor
+          excludes: Main,System.AppTestCase,System.Persistence,Unit.Libs.Download.MealyMachine,Unit.Libs.Download.Parsers,Unit.Libs.Download.Time,Unit.Libs.Serve,Unit.Libs.Types.ClubPerformanceReportDescriptor,Unit.Common.Sorting
           mix: dist-newstyle/build/x86_64-linux/ghc-9.12.2/ts-data-0.1.0.0/build/extra-compilation-artifacts/hpc/vanilla/mix
 
       - name: Upload coverage to Codecov

--- a/test/Unit/Common/Sorting.hs
+++ b/test/Unit/Common/Sorting.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Unit.Common.Sorting (sortByFirst, sortByDate) where
 
 import Data.Bifunctor (second)
@@ -7,7 +5,7 @@ import Data.List (sortBy)
 import Data.Ord (comparing)
 import Data.Text (Text)
 
-import Types.ClubMeasurementResponse (Codomain(..), Series(..))
+import Types.ClubMeasurementResponse (Codomain (..), Series (..))
 
 -- | Sort a pair of correlated lists by the first list.
 sortByFirst :: [Text] -> [a] -> ([Text], [a])

--- a/test/Unit/Common/Sorting.hs
+++ b/test/Unit/Common/Sorting.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Unit.Common.Sorting (sortByFirst, sortByDate) where
+
+import Data.Bifunctor (second)
+import Data.List (sortBy)
+import Data.Ord (comparing)
+import Data.Text (Text)
+
+import Types.ClubMeasurementResponse (Codomain(..), Series(..))
+
+-- | Sort a pair of correlated lists by the first list.
+sortByFirst :: [Text] -> [a] -> ([Text], [a])
+sortByFirst xs ys = unzip $ (sortBy . comparing) fst $ zip xs ys
+
+-- | Sort the domain and codomain of each 'Series' by its domain values.
+sortByDate :: [Series] -> [Series]
+sortByDate seriesList = do
+  Series{label, domain, codomain} <- seriesList
+  let (xs, ys) = case codomain of
+        IntCodomain intCodomain -> second IntCodomain $ sortByFirst domain intCodomain
+        TextCodomain textCodomain -> second TextCodomain $ sortByFirst domain textCodomain
+  pure $ Series label xs ys

--- a/test/Unit/Libs/Download/Parsers.hs
+++ b/test/Unit/Libs/Download/Parsers.hs
@@ -3,11 +3,8 @@
 
 module Unit.Libs.Download.Parsers where
 
-import Data.Bifunctor (second)
 import Data.ByteString.Lazy.Char8 qualified as BL8 (pack)
-import Data.List (intercalate, sortBy, uncons)
-import Data.Ord (comparing)
-import Data.Text (Text)
+import Data.List (intercalate, uncons)
 import Data.Time (pattern YearMonthDay)
 import Data.Time.Calendar.Month (pattern YearMonth)
 import Test.Tasty (TestTree, testGroup)
@@ -18,17 +15,7 @@ import Download.Parsers (decodeClubReport, parseFooter)
 import Types.ClubMeasurementResponse (Codomain (..), Series (..))
 import Types.ClubNumber (ClubNumber (..))
 import Types.ClubPerformanceReport (ClubPerformanceRecord (..), ClubPerformanceReport (..))
-
-sortByFirst :: [Text] -> [a] -> ([Text], [a])
-sortByFirst xs ys = unzip $ (sortBy . comparing) fst $ zip xs ys
-
-sortByDate :: [Series] -> [Series]
-sortByDate seriesList = do
-  Series{label, domain, codomain} <- seriesList
-  let (xs, ys) = case codomain of
-        IntCodomain intCodomain -> second IntCodomain $ sortByFirst domain intCodomain
-        TextCodomain textCodomain -> second TextCodomain $ sortByFirst domain textCodomain
-  pure $ Series label xs ys
+import Unit.Common.Sorting (sortByDate)
 
 tests :: TestTree
 tests =

--- a/test/Unit/Libs/Serve.hs
+++ b/test/Unit/Libs/Serve.hs
@@ -3,10 +3,6 @@
 
 module Unit.Libs.Serve where
 
-import Data.Bifunctor (second)
-import Data.List (sortBy)
-import Data.Ord (comparing)
-import Data.Text (Text)
 import Data.Time (pattern YearMonthDay)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
@@ -18,17 +14,7 @@ import Serve.ClubMeasurement (buildIntSeries)
 import Types.ClubMeasurementResponse (Codomain (..), Series (..))
 import Types.ClubMetric (ClubMetric (..))
 import Types.ClubNumber (ClubNumber (..))
-
-sortByFirst :: [Text] -> [a] -> ([Text], [a])
-sortByFirst xs ys = unzip $ (sortBy . comparing) fst $ zip xs ys
-
-sortByDate :: [Series] -> [Series]
-sortByDate seriesList = do
-  Series{label, domain, codomain} <- seriesList
-  let (xs, ys) = case codomain of
-        IntCodomain intCodomain -> second IntCodomain $ sortByFirst domain intCodomain
-        TextCodomain textCodomain -> second TextCodomain $ sortByFirst domain textCodomain
-  pure $ Series label xs ys
+import Unit.Common.Sorting (sortByDate)
 
 tests :: TestTree
 tests =

--- a/ts-data.cabal
+++ b/ts-data.cabal
@@ -313,4 +313,3 @@ test-suite ts-data-test
         time ^>=1.14,
         unliftio ^>=0.2.25.1,
         ts-data
-

--- a/ts-data.cabal
+++ b/ts-data.cabal
@@ -283,7 +283,8 @@ test-suite ts-data-test
         Unit.Libs.Download.Parsers,
         Unit.Libs.Download.Time,
         Unit.Libs.Serve,
-        Unit.Libs.Types.ClubPerformanceReportDescriptor
+        Unit.Libs.Types.ClubPerformanceReportDescriptor,
+        Unit.Common.Sorting
 
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:


### PR DESCRIPTION
## Summary
- add new `Unit.Common.Sorting` with shared helpers
- remove duplicate sorting helpers in `Parsers` and `Serve`
- import the new helper module in tests
- expose module in cabal file

## Testing
- `cabal test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68697097fe6483259f3a0d66a6c62a8e